### PR TITLE
Add Express backend for resume draft persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.env
+npm-debug.log*
+.DS_Store
+data/resumes.json

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![CSS3](https://img.shields.io/badge/CSS3-blue?logo=css3\&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-yellow?logo=javascript\&logoColor=black)
 
-A lightweight, browser-based resume builder to quickly draft a professional CV and export it as a PDF. No signup. No backend. Just open and edit.
+A lightweight, browser-based resume builder to quickly draft a professional CV and export it as a PDF. No signup required—and now includes an optional Node.js backend so you can save and reload drafts from any device.
 
 [**Live Demo**](https://basic-resume-builder-lemon.vercel.app/) • [**Repository**](https://github.com/NehitPahuja/Basic-resume-builder)
 
@@ -17,20 +17,47 @@ A lightweight, browser-based resume builder to quickly draft a professional CV a
 * Work/Education sections: Add roles and programs interactively.
 * Skills block: Simple list for quick scanning.
 * One-click PDF: Use the **Download PDF** button to export your resume.
-* No server required: 100% static — HTML, CSS, and JavaScript only.
+* Save & load drafts: Persist resumes to the Express backend and reload them later with a shareable draft ID.
 
 ## Tech Stack
 
 * HTML5 – structure
 * CSS3 – layout & styles
 * Vanilla JavaScript – interactivity (form fields, add/remove items, PDF trigger)
+* Node.js + Express – lightweight REST API for saving and loading resume drafts
 
 
-3. **Use**
+## Getting Started
 
-   * Click fields to edit content.
+1. **Clone the repository**
+
+   ```bash
+   git clone https://github.com/NehitPahuja/Basic-resume-builder.git
+   cd Basic-resume-builder
+   ```
+
+2. **Install dependencies**
+
+   ```bash
+   npm install
+   ```
+
+3. **Start the backend + static server**
+
+   ```bash
+   npm start
+   ```
+
+   The app will be available at [http://localhost:4000](http://localhost:4000).
+
+4. **Build your resume**
+
+   * Click fields to edit content in the live preview.
    * Add entries under **Work History** / **Education**.
-   * Click **Download PDF** to export.
+   * Click **Save Draft** to store a copy on the backend—an ID will be generated so you can reload it later with **Load Draft**.
+   * Click **Download PDF** to export a polished copy.
+
+> Prefer the original static version? Open `index.html` directly in your browser without starting the backend (save/load will be unavailable).
 
 ## Project Structure
 
@@ -38,8 +65,25 @@ A lightweight, browser-based resume builder to quickly draft a professional CV a
 .
 ├─ index.html     # Layout & content areas
 ├─ styles.css     # Styling
-└─ script.js      # Field logic, add/remove items, PDF trigger
+├─ script.js      # Field logic, add/remove items, PDF trigger, backend integration
+├─ server.js      # Express server that serves static assets + REST API
+├─ package.json   # Project metadata & dependencies
+├─ data/          # JSON storage for saved drafts (gitignored)
+└─ .gitignore
 ```
+
+## REST API
+
+The backend persists drafts to `data/resumes.json` on disk and exposes a small REST API:
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `GET`  | `/api/health` | Health check for uptime monitoring. |
+| `POST` | `/api/resumes` | Save a draft. Expects the same shape as the frontend state and returns `{ id }`. |
+| `GET`  | `/api/resumes` | List saved drafts with minimal metadata (ID, name, job title, timestamp). |
+| `GET`  | `/api/resumes/:id` | Retrieve a full draft by ID for loading back into the editor. |
+
+> Drafts are stored unencrypted on disk for simplicity. Use environment-level protections or swap in a different persistence layer before deploying publicly.
 
 ## Deploy
 

--- a/index.html
+++ b/index.html
@@ -23,10 +23,24 @@
             <p>Shape a professional story that stands out.</p>
           </div>
         </div>
-        <button id="download-btn" class="primary-button" type="button">
-          Download PDF
-        </button>
+        <div class="header-actions" role="group" aria-label="Resume actions">
+          <button id="save-btn" class="secondary-button" type="button">
+            Save Draft
+          </button>
+          <button id="load-btn" class="secondary-button" type="button">
+            Load Draft
+          </button>
+          <button id="download-btn" class="primary-button" type="button">
+            Download PDF
+          </button>
+        </div>
       </header>
+      <p
+        id="save-status"
+        class="status-message"
+        role="status"
+        aria-live="polite"
+      ></p>
 
       <div class="layout">
         <section class="preview-panel" aria-label="Live resume preview">

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "basic-resume-builder",
+  "version": "1.0.0",
+  "description": "A resume builder with a simple Express backend for saving and loading drafts.",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js"
+  },
+  "keywords": [
+    "resume",
+    "builder",
+    "express",
+    "backend"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.3",
+    "uuid": "^9.0.1"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,140 @@
+const path = require('path');
+const fs = require('fs/promises');
+const express = require('express');
+const cors = require('cors');
+const { v4: uuid } = require('uuid');
+
+const app = express();
+const PORT = process.env.PORT || 4000;
+const DATA_DIR = path.join(__dirname, 'data');
+const DATA_FILE = path.join(DATA_DIR, 'resumes.json');
+
+app.use(cors());
+app.use(express.json({ limit: '1mb' }));
+app.use(express.static(__dirname));
+
+const readResumes = async () => {
+  try {
+    const buffer = await fs.readFile(DATA_FILE, 'utf8');
+    const parsed = JSON.parse(buffer);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed;
+    }
+    return {};
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return {};
+    }
+    throw error;
+  }
+};
+
+const writeResumes = async (data) => {
+  await fs.mkdir(DATA_DIR, { recursive: true });
+  await fs.writeFile(DATA_FILE, JSON.stringify(data, null, 2), 'utf8');
+};
+
+const normalizePersonal = (personal = {}) => ({
+  fullName: typeof personal.fullName === 'string' ? personal.fullName.trim() : '',
+  jobTitle: typeof personal.jobTitle === 'string' ? personal.jobTitle.trim() : '',
+  email: typeof personal.email === 'string' ? personal.email.trim() : '',
+  phone: typeof personal.phone === 'string' ? personal.phone.trim() : '',
+  location: typeof personal.location === 'string' ? personal.location.trim() : '',
+  website: typeof personal.website === 'string' ? personal.website.trim() : '',
+  summary: typeof personal.summary === 'string' ? personal.summary.trim() : '',
+});
+
+const normalizeArrayOfObjects = (value, template) => {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item) => item && typeof item === 'object')
+    .map((item) => ({ ...template(), ...item }));
+};
+
+const normalizeExperiences = (experiences) =>
+  normalizeArrayOfObjects(experiences, () => ({
+    title: '',
+    company: '',
+    location: '',
+    start: '',
+    end: '',
+    description: '',
+  }));
+
+const normalizeEducations = (educations) =>
+  normalizeArrayOfObjects(educations, () => ({
+    program: '',
+    school: '',
+    year: '',
+    details: '',
+  }));
+
+const normalizeSkills = (skills) => {
+  if (!Array.isArray(skills)) return [];
+  return skills
+    .map((skill) => (typeof skill === 'string' ? skill.trim() : ''))
+    .filter(Boolean);
+};
+
+app.get('/api/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.post('/api/resumes', async (req, res, next) => {
+  try {
+    const payload = req.body || {};
+    const resume = {
+      personal: normalizePersonal(payload.personal),
+      experiences: normalizeExperiences(payload.experiences),
+      educations: normalizeEducations(payload.educations),
+      skills: normalizeSkills(payload.skills),
+      savedAt: new Date().toISOString(),
+    };
+
+    const resumes = await readResumes();
+    const id = uuid();
+    resumes[id] = resume;
+    await writeResumes(resumes);
+
+    res.status(201).json({ id });
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.get('/api/resumes', async (_req, res, next) => {
+  try {
+    const resumes = await readResumes();
+    const list = Object.entries(resumes).map(([id, resume]) => ({
+      id,
+      savedAt: resume.savedAt,
+      fullName: resume.personal?.fullName || '',
+      jobTitle: resume.personal?.jobTitle || '',
+    }));
+    res.json(list);
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.get('/api/resumes/:id', async (req, res, next) => {
+  try {
+    const resumes = await readResumes();
+    const resume = resumes[req.params.id];
+    if (!resume) {
+      return res.status(404).json({ message: 'Draft not found' });
+    }
+    res.json(resume);
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.use((err, _req, res, _next) => {
+  console.error(err);
+  res.status(500).json({ message: 'Unexpected server error' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Resume backend listening on http://localhost:${PORT}`);
+});

--- a/styles.css
+++ b/styles.css
@@ -105,6 +105,53 @@ body {
   box-shadow: none;
 }
 
+.secondary-button {
+  border: 1px solid rgba(90, 84, 241, 0.3);
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--primary);
+  font-weight: 600;
+  font-size: 0.9rem;
+  padding: 0.7rem 1.4rem;
+  border-radius: 14px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border 0.2s ease;
+}
+
+.secondary-button:hover {
+  background: rgba(90, 84, 241, 0.08);
+  border-color: rgba(90, 84, 241, 0.45);
+}
+
+.secondary-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.status-message {
+  margin: -1.25rem 0 2rem;
+  text-align: right;
+  font-size: 0.9rem;
+  color: var(--muted);
+  min-height: 1.5rem;
+  transition: color 0.2s ease;
+}
+
+.status-message.status-success {
+  color: #1f7a4d;
+}
+
+.status-message.status-error {
+  color: #d23f3f;
+}
+
 .layout {
   display: grid;
   grid-template-columns: minmax(360px, 0.95fr) minmax(380px, 1.05fr);
@@ -539,6 +586,15 @@ textarea {
   .app-header {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .header-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .status-message {
+    text-align: left;
   }
 
   .layout {


### PR DESCRIPTION
## Summary
- add an Express server that serves the static app and exposes REST endpoints to save and load resume drafts
- wire up the editor with save/load buttons, status messaging, and unsaved change tracking that integrates with the backend
- refresh the styles and README with action button treatments and backend setup/API documentation

## Testing
- node --check server.js